### PR TITLE
use ros::time:now as timestamp

### DIFF
--- a/livox_ros_driver/livox_ros_driver/lddc.cpp
+++ b/livox_ros_driver/livox_ros_driver/lddc.cpp
@@ -202,9 +202,8 @@ uint32_t Lddc::PublishPointcloud2(LidarDataQueue *queue, uint32_t packet_num,
       }
     }
     /** Use the first packet timestamp as pointcloud2 msg timestamp */
-    if (!published_packet) {
-      cloud.header.stamp = ros::Time(timestamp / 1000000000.0);
-    }
+    // TODO: synchronize device and computer and get device timestamp
+    cloud.header.stamp = ros::Time::now();
     uint32_t single_point_num = storage_packet.point_num * echo_num;
 
     if (kSourceLvxFile != data_source) {


### PR DESCRIPTION
this PR changes to use ros::time::now as timestamp